### PR TITLE
Expose TimeTrace::record(timestamp, ...) in the c wrapper.

### DIFF
--- a/cwrapper/timetrace_wrapper.cc
+++ b/cwrapper/timetrace_wrapper.cc
@@ -53,6 +53,19 @@ timetrace_record(const char* format, uint32_t arg0, uint32_t arg1,
 }
 
 /**
+ * This function is the wrapper for TimeTrace::record
+ *
+ * Since C does not support default value, caller always needs to pass arg0-3.
+ * Also, we cannot separate definition and declaration of inline function, so
+ * this function cannot be inline function.
+ */
+void
+timetrace_record_ts(uint64_t timestamp, const char* format, uint32_t arg0,
+                    uint32_t arg1, uint32_t arg2, uint32_t arg3) {
+    TimeTrace::record(timestamp, format, arg0, arg1, arg2, arg3);
+}
+
+/**
  * This function is used to set TimeTrace::keepOldEvents
  */
 void

--- a/cwrapper/timetrace_wrapper.h
+++ b/cwrapper/timetrace_wrapper.h
@@ -35,6 +35,15 @@ void timetrace_print();
  *                       uint32_t arg2, uint32_t arg3);
  */
 void timetrace_record();
+/**
+ * The real signature of this function is the following. The timestamp and the
+ * format string are mandatory; remaining arguments are only necessary as
+ * specified by format string.
+ * void timetrace_record_ts(uint64_t timestamp, const char* format,
+ *                          uint32_t arg0, uint32_t arg1, uint32_t arg2,
+ *                          uint32_t arg3);
+ */
+void timetrace_record_ts();
 void timetrace_set_keepoldevents(bool keep);
 
 #ifdef __cplusplus

--- a/src/TimeTrace.cc
+++ b/src/TimeTrace.cc
@@ -348,9 +348,9 @@ TimeTrace::printInternal(std::vector<TimeTrace::Buffer*>* buffers, string* s) {
 
     if (!printedAnything) {
         if (s != NULL) {
-            s->append("No time trace events to print");
+            s->append("No time trace events to print\n");
         } else {
-            fprintf(output, "No time trace events to print");
+            fprintf(output, "No time trace events to print\n");
         }
     }
 


### PR DESCRIPTION
https://github.com/PlatformLab/PerfUtils/issues/15